### PR TITLE
Enable go.mod support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/convert_test.go
+++ b/convert_test.go
@@ -21,3 +21,29 @@ func testShortType(t *testing.T, input, output string) {
 		t.Errorf("%v should result in %v but did result in %v", input, output, result)
 	}
 }
+
+func Test_gopathImport(t *testing.T) {
+	type args struct {
+		dir string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "in GOPATH",
+			args: args{
+				dir: "/Users/someonefamous/go/src/github.com/someonefamous/famous-project",
+			},
+			want: "github.com/someonefamous/famous-project",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gopathImport(tt.args.dir); got != tt.want {
+				t.Errorf("gopathImport() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/convert_test.go
+++ b/convert_test.go
@@ -21,29 +21,3 @@ func testShortType(t *testing.T, input, output string) {
 		t.Errorf("%v should result in %v but did result in %v", input, output, result)
 	}
 }
-
-func Test_gopathImport(t *testing.T) {
-	type args struct {
-		dir string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "in GOPATH",
-			args: args{
-				dir: "/Users/someonefamous/go/src/github.com/someonefamous/famous-project",
-			},
-			want: "github.com/someonefamous/famous-project",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := gopathImport(tt.args.dir); got != tt.want {
-				t.Errorf("gopathImport() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/vektah/gqlparser/v2 v2.0.1
 	github.com/web-ridge/go-pluralize v0.1.5
+	golang.org/x/mod v0.3.0 // indirect
 	golang.org/x/tools v0.0.0-20200507205054-480da3ebd79c
 )

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
+golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/helpers.go
+++ b/helpers.go
@@ -1,8 +1,9 @@
 package gqlgen_sqlboiler
 
 import (
-	"bufio"
 	"fmt"
+	"golang.org/x/mod/modfile"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -80,28 +81,16 @@ func fileExists(filename string) bool {
 
 func getModulePath(projectPath string) (string, error) {
 	filePath := path.Join(projectPath, "go.mod")
-	file, err := os.Open(filePath)
+	file, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return "", fmt.Errorf("error while trying to read go mods path %w", err)
 	}
-	defer file.Close()
 
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		// normalize to ensure readability
-		line := strings.TrimSpace(scanner.Text())
-
-		// look for the starting module statement
-		if strings.HasPrefix(line, "module") {
-			split := strings.Split(line, "module")
-			return strings.TrimSpace(split[1]), nil
-		}
+	modPath := modfile.ModulePath(file)
+	if modPath == "" {
+		return "", fmt.Errorf("could not determine mod path \n")
 	}
-
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("error while trying to read go mods path %w", err)
-	}
-	return "", nil
+	return modPath, nil
 }
 
 func gopathImport(dir string) string {

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,109 @@
+package gqlgen_sqlboiler
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+func getRootImportPath() string {
+	importPath, err := rootImportPath()
+	if err != nil {
+		fmt.Printf("error while getting root import path %v", err)
+		return ""
+	}
+	return importPath
+}
+
+func getGoImportFromFile(dir string) string {
+	dir = strings.TrimPrefix(dir, "/")
+	importPath, err := rootImportPath()
+	if err != nil {
+		fmt.Printf("error while getting root import path %v", err)
+		return ""
+	}
+	return path.Join(importPath, dir)
+}
+
+func rootImportPath() (string, error) {
+	projectPath, err := getWorkingPath()
+	if err != nil {
+		// TODO: adhering to your original error handling
+		//  should consider doing something here rather than continuing
+		//  since this step occurs during generation, panicing or fatal error should be okay
+		return "", fmt.Errorf("error while getting working directory %w", err)
+	}
+	if hasGoMod(projectPath) {
+		modulePath, err := getModulePath(projectPath)
+		if err != nil {
+			// TODO: adhering to your original error handling
+			//  should consider doing something here rather than continuing
+			//  since this step occurs during generation, panicing or fatal error should be okay
+			return "", fmt.Errorf("error while getting module path %w", err)
+		}
+		return modulePath, nil
+	}
+
+	return gopathImport(projectPath), nil
+}
+func getProjectPath(dir string) (string, error) {
+	longPath, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("error while trying to convert folder to gopath %w", err)
+	}
+	return strings.TrimSuffix(longPath, dir), nil
+}
+
+// getWorkingPath gets the current working directory
+func getWorkingPath() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return wd, nil
+}
+func hasGoMod(projectPath string) bool {
+	filePath := path.Join(projectPath, "go.mod")
+	return fileExists(filePath)
+}
+
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func getModulePath(projectPath string) (string, error) {
+	filePath := path.Join(projectPath, "go.mod")
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("error while trying to read go mods path %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		// normalize to ensure readability
+		line := strings.TrimSpace(scanner.Text())
+
+		// look for the starting module statement
+		if strings.HasPrefix(line, "module") {
+			split := strings.Split(line, "module")
+			return strings.TrimSpace(split[1]), nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error while trying to read go mods path %w", err)
+	}
+	return "", nil
+}
+
+func gopathImport(dir string) string {
+	return strings.TrimPrefix(pathRegex.FindString(dir), "src/")
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,29 @@
+package gqlgen_sqlboiler
+
+import "testing"
+
+func Test_gopathImport(t *testing.T) {
+	type args struct {
+		dir string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "in GOPATH",
+			args: args{
+				dir: "/Users/someonefamous/go/src/github.com/someonefamous/famous-project",
+			},
+			want: "github.com/someonefamous/famous-project",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gopathImport(tt.args.dir); got != tt.want {
+				t.Errorf("gopathImport() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/resolver.go
+++ b/resolver.go
@@ -3,6 +3,7 @@ package gqlgen_sqlboiler
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -16,14 +17,15 @@ import (
 )
 
 func NewResolverPlugin(output, backend, frontend Config, authImport string) plugin.Plugin {
-	return &ResolverPlugin{output: output, backend: backend, frontend: frontend, authImport: authImport}
+	return &ResolverPlugin{output: output, backend: backend, frontend: frontend, authImport: authImport, rootImportPath: getRootImportPath()}
 }
 
 type ResolverPlugin struct {
-	output     Config
-	backend    Config
-	frontend   Config
-	authImport string
+	output         Config
+	backend        Config
+	frontend       Config
+	authImport     string
+	rootImportPath string
 }
 
 var _ plugin.CodeGenerator = &ResolverPlugin{}
@@ -61,16 +63,16 @@ func (m *ResolverPlugin) generateSingleFile(data *codegen.Data, models []*Model,
 
 	file.imports = append(file.imports, Import{
 		Alias:      ".",
-		ImportPath: getGoImportFromFile(m.output.Directory),
+		ImportPath: path.Join(m.rootImportPath, m.output.Directory),
 	})
 
 	file.imports = append(file.imports, Import{
 		Alias:      "dm",
-		ImportPath: getGoImportFromFile(m.backend.Directory),
+		ImportPath: path.Join(m.rootImportPath, m.backend.Directory),
 	})
 	file.imports = append(file.imports, Import{
 		Alias:      "fm",
-		ImportPath: getGoImportFromFile(m.frontend.Directory),
+		ImportPath: path.Join(m.rootImportPath, m.frontend.Directory),
 	})
 
 	if m.authImport != "" {


### PR DESCRIPTION
Enables go mod support and works outside of GOPATH directory. I left a few TODO comments in the funcs for review and more tests should be created, but this worked in my local testing both in GOPATH and outside using modules.

addresses issue #29 

The approach I took:
Since a go.mod file and processes works inside and outside of the GOPATH (as of 1.13 or 1.14 https://github.com/golang/go/issues/31857), I figured we could easily check whether or not a go.mod file exists in the working directory. If it does, we can open and read the file, retrieve the module path and move on. if not, use original method of getting import path from go/src