### PR TITLE
Fix import path on windows, Dir() returns backslashed path, in the fi…

### DIFF
--- a/resolver_plugin.go
+++ b/resolver_plugin.go
@@ -89,12 +89,12 @@ func (m *ResolverPlugin) generateSingleFile(data *codegen.Data, models []*Model,
 
 	file.Imports = append(file.Imports, Import{
 		Alias:      "fm",
-		ImportPath: path.Join(m.rootImportPath, m.frontend.Directory),
+		ImportPath: path.Join(m.rootImportPath, m.frontend.Directory),	
 	})
 
 	file.Imports = append(file.Imports, Import{
 		Alias:      "gm",
-		ImportPath: buildImportPath(m.rootImportPath, data.Config.Exec.Dir()),
+		ImportPath: buildImportPath(m.rootImportPath, data.Config.Exec.ImportPath()),
 	})
 
 	for _, scope := range m.pluginConfig.AuthorizationScopes {


### PR DESCRIPTION
Fix import path on windows:

Dir() returns backslashed path, this filepath is then used as an import path in the resolver.go file.

resolver.go is then passed to the go AST parser, a backslashed import path then fails as it contains an invalid escape sequence.

Compiler then errors with the following error:

`contentError: formatting: 38:14: unknown escape sequence, importError: E:/server/resolver.go:38:14: unknown escape sequence
exit status 3
`
